### PR TITLE
fixbug: Add description to keymaps

### DIFF
--- a/lua/textcase/extensions/whichkey.lua
+++ b/lua/textcase/extensions/whichkey.lua
@@ -1,0 +1,75 @@
+local M = {}
+
+M.state = {
+  queue_normal_mappings = {},
+  queue_visual_mappings = {},
+}
+
+function M.add(opts)
+  local queue_ref = opts.mode == 'n' and M.state.queue_normal_mappings or M.state.queue_visual_mappings
+  queue_ref[opts.keybind] = { opts.command, opts.desc }
+end
+
+function M.register_batch(prefix)
+  local normal_opts = {
+    mode = "n",
+    buffer = nil,
+    silent = true,
+    noremap = true,
+    nowait = true,
+  }
+  local visual_opts = {
+    mode = "v",
+    prefix = "<leader>",
+    buffer = nil,
+    silent = true,
+    noremap = true,
+    nowait = true,
+  }
+
+  local normal_mapping = {
+    [prefix] = {
+      name = "text-case",
+      o = {
+        name = "Pending mode"
+      }
+    }
+  }
+  local visual_mapping = {
+    [prefix] = M.state.queue_visual_mappings
+  }
+
+  -- build mapping dictionary for which key
+  for keybind, command_and_desc in pairs(M.state.queue_normal_mappings) do
+    if #keybind == 2 and keybind[1] == 'o' then
+      normal_mapping[prefix]['o'][keybind[2]] = command_and_desc
+    else
+      normal_mapping[prefix][keybind] = command_and_desc
+    end
+  end
+
+  for _, mappings_table in pairs({
+    { 'queue_normal_mappings', normal_mapping, normal_opts },
+    { 'queue_visual_mappings', visual_mapping, visual_opts }
+  }) do
+    local queue_key, mapping, opts = unpack(mappings_table)
+    if not pcall(
+      require("which-key").register,
+      mapping,
+      opts
+    ) then
+      for keybind, command_and_desc in pairs(M.state[queue_key]) do
+        vim.api.nvim_set_keymap(
+          'n',
+          prefix .. keybind,
+          command_and_desc[1],
+          { noremap = true }
+        )
+      end
+    end
+
+    M.state[queue_key] = {}
+  end
+end
+
+return M

--- a/lua/textcase/extensions/whichkey.lua
+++ b/lua/textcase/extensions/whichkey.lua
@@ -1,75 +1,28 @@
 local M = {}
 
-M.state = {
-  queue_normal_mappings = {},
-  queue_visual_mappings = {},
-}
-
-function M.add(opts)
-  local queue_ref = opts.mode == 'n' and M.state.queue_normal_mappings or M.state.queue_visual_mappings
-  queue_ref[opts.keybind] = { opts.command, opts.desc }
-end
-
-function M.register_batch(prefix)
-  local normal_opts = {
-    mode = "n",
-    buffer = nil,
-    silent = true,
-    noremap = true,
-    nowait = true,
-  }
-  local visual_opts = {
-    mode = "v",
-    prefix = "<leader>",
-    buffer = nil,
-    silent = true,
-    noremap = true,
-    nowait = true,
-  }
-
-  local normal_mapping = {
-    [prefix] = {
-      name = "text-case",
-      o = {
-        name = "Pending mode"
-      }
+function M.register(mode, mappings)
+  local opts = {
+    n = {
+      mode = "n",
+      buffer = nil,
+      silent = true,
+      noremap = true,
+      nowait = true,
+    },
+    v = {
+      mode = "v",
+      buffer = nil,
+      silent = true,
+      noremap = true,
+      nowait = true,
     }
   }
-  local visual_mapping = {
-    [prefix] = M.state.queue_visual_mappings
-  }
 
-  -- build mapping dictionary for which key
-  for keybind, command_and_desc in pairs(M.state.queue_normal_mappings) do
-    if #keybind == 2 and keybind[1] == 'o' then
-      normal_mapping[prefix]['o'][keybind[2]] = command_and_desc
-    else
-      normal_mapping[prefix][keybind] = command_and_desc
-    end
-  end
-
-  for _, mappings_table in pairs({
-    { 'queue_normal_mappings', normal_mapping, normal_opts },
-    { 'queue_visual_mappings', visual_mapping, visual_opts }
-  }) do
-    local queue_key, mapping, opts = unpack(mappings_table)
-    if not pcall(
-      require("which-key").register,
-      mapping,
-      opts
-    ) then
-      for keybind, command_and_desc in pairs(M.state[queue_key]) do
-        vim.api.nvim_set_keymap(
-          'n',
-          prefix .. keybind,
-          command_and_desc[1],
-          { noremap = true }
-        )
-      end
-    end
-
-    M.state[queue_key] = {}
-  end
+  pcall(
+    require("which-key").register,
+    mappings,
+    opts[mode]
+  )
 end
 
 return M

--- a/lua/textcase/plugin/plugin.lua
+++ b/lua/textcase/plugin/plugin.lua
@@ -1,7 +1,6 @@
 local utils = require("textcase.shared.utils")
 local constants = require("textcase.shared.constants")
 local conversion = require("textcase.plugin.conversion")
-local whichkey = require("textcase.extensions.whichkey")
 local flag_incremental_preview = vim.fn.has("nvim-0.8-dev+374-ge13dcdf16") == 1
 
 local M = {}
@@ -49,12 +48,6 @@ function M.register_keybindings(prefix, method_table, keybindings, opts)
         { desc = desc }
       )
 
-      -- whichkey.add({
-      --   mode = mode,
-      --   keybind = keybindings[feature],
-      --   command = "<cmd>lua require('" .. constants.namespace .. "')." .. feature .. "('" .. method_table.desc .. "')<cr>",
-      --   desc = desc
-      -- })
     end
   end
 

--- a/lua/textcase/plugin/plugin.lua
+++ b/lua/textcase/plugin/plugin.lua
@@ -1,7 +1,7 @@
 local utils = require("textcase.shared.utils")
 local constants = require("textcase.shared.constants")
 local conversion = require("textcase.plugin.conversion")
-local config = require("textcase.plugin.config")
+local whichkey = require("textcase.extensions.whichkey")
 local flag_incremental_preview = vim.fn.has("nvim-0.8-dev+374-ge13dcdf16") == 1
 
 local M = {}
@@ -16,7 +16,7 @@ M.state = {
   substitute = {},
 }
 
-function M.register_keybindings(method_table, keybindings, opts)
+function M.register_keybindings(prefix, method_table, keybindings, opts)
   -- TODO: validate method_table
   M.state.methods_by_desc[method_table.desc] = method_table
   M.state.methods_by_desc[method_table.desc].opts = opts
@@ -34,19 +34,36 @@ function M.register_keybindings(method_table, keybindings, opts)
       if feature == 'visual' then
         mode = 'v'
       end
-      vim.api.nvim_set_keymap(
+      local desc = method_table.desc
+
+      if feature == 'current_word' then
+        desc = 'Convert ' .. desc
+      elseif feature == 'lsp_rename' then
+        desc = 'LSP rename ' .. desc
+      end
+
+      vim.keymap.set(
         mode,
-        keybindings[feature],
+        prefix .. keybindings[feature],
         "<cmd>lua require('" .. constants.namespace .. "')." .. feature .. "('" .. method_table.desc .. "')<cr>",
-        { noremap = true }
+        { desc = desc }
       )
+
+      -- whichkey.add({
+      --   mode = mode,
+      --   keybind = keybindings[feature],
+      --   command = "<cmd>lua require('" .. constants.namespace .. "')." .. feature .. "('" .. method_table.desc .. "')<cr>",
+      --   desc = desc
+      -- })
     end
   end
+
+  -- whichkey.register_batch(prefix)
 end
 
-function M.register_keys(method_table, keybindings)
+function M.register_keys(prefix, method_table, keybindings)
   -- Sugar syntax
-  M.register_keybindings(method_table, {
+  M.register_keybindings(prefix, method_table, {
     line = keybindings[1],
     eol = keybindings[2],
     visual = keybindings[3],
@@ -112,10 +129,6 @@ function M.incremental_substitute(opts, preview_ns, preview_buf)
   local params = vim.split(opts.args, '/')
   local source, dest = params[2], params[3]
   local buf = (preview_ns ~= nil) and preview_buf or vim.api.nvim_get_current_buf()
-
-  if M.state.substitute.list == nil then
-
-  end
 
   local cursor_pos = vim.fn.getpos(".")
   vim.api.nvim_buf_clear_namespace(buf, 1, 0, -1)

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -2,9 +2,25 @@ local M = {}
 
 local plugin = require('textcase.plugin.plugin')
 local api = require('textcase.plugin.api')
+local whichkey = require("textcase.extensions.whichkey")
 
 M.setup = function(opts)
   local prefix = opts and opts.prefix or 'ga'
+
+  whichkey.register('v', {
+    [prefix] = {
+      name = 'text-case',
+    }
+  })
+
+  whichkey.register('n', {
+    [prefix] = {
+      name = 'text-case',
+      o = {
+        name = 'Pending mode operator'
+      }
+    }
+  })
 
   plugin.register_keybindings(prefix, api.to_constant_case, {
     prefix = prefix,

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -6,41 +6,47 @@ local api = require('textcase.plugin.api')
 M.setup = function(opts)
   local prefix = opts and opts.prefix or 'ga'
 
-  plugin.register_keybindings(api.to_constant_case, {
-    current_word = prefix .. 'n',
-    visual = prefix .. 'n',
-    operator = prefix .. 'on',
-    lsp_rename = prefix .. 'N',
+  plugin.register_keybindings(prefix, api.to_constant_case, {
+    prefix = prefix,
+    current_word = 'n',
+    visual = 'n',
+    operator = 'on',
+    lsp_rename = 'N',
   })
-  plugin.register_keybindings(api.to_camel_case, {
-    current_word = prefix .. 'c',
-    visual = prefix .. 'c',
-    operator = prefix .. 'oc',
-    lsp_rename = prefix .. 'C',
+  plugin.register_keybindings(prefix, api.to_camel_case, {
+    prefix = prefix,
+    current_word = 'c',
+    visual = 'c',
+    operator = 'oc',
+    lsp_rename = 'C',
   })
-  plugin.register_keybindings(api.to_dash_case, {
-    current_word = prefix .. 'd',
-    visual = prefix .. 'd',
-    operator = prefix .. 'od',
-    lsp_rename = prefix .. 'D',
+  plugin.register_keybindings(prefix, api.to_dash_case, {
+    prefix = prefix,
+    current_word = 'd',
+    visual = 'd',
+    operator = 'od',
+    lsp_rename = 'D',
   })
-  plugin.register_keybindings(api.to_pascal_case, {
-    current_word = prefix .. 'p',
-    visual = prefix .. 'p',
-    operator = prefix .. 'op',
-    lsp_rename = prefix .. 'P',
+  plugin.register_keybindings(prefix, api.to_pascal_case, {
+    prefix = prefix,
+    current_word = 'p',
+    visual = 'p',
+    operator = 'op',
+    lsp_rename = 'P',
   })
-  plugin.register_keybindings(api.to_upper_case, {
-    current_word = prefix .. 'u',
-    visual = prefix .. 'u',
-    operator = prefix .. 'ou',
-    lsp_rename = prefix .. 'U',
+  plugin.register_keybindings(prefix, api.to_upper_case, {
+    prefix = prefix,
+    current_word = 'u',
+    visual = 'u',
+    operator = 'ou',
+    lsp_rename = 'U',
   })
-  plugin.register_keybindings(api.to_lower_case, {
-    current_word = prefix .. 'l',
-    visual = prefix .. 'l',
-    operator = prefix .. 'ol',
-    lsp_rename = prefix .. 'L',
+  plugin.register_keybindings(prefix, api.to_lower_case, {
+    prefix = prefix,
+    current_word = 'l',
+    visual = 'l',
+    operator = 'ol',
+    lsp_rename = 'L',
   })
 
   plugin.register_replace_command('Subs', {


### PR DESCRIPTION
This PR adds description to the keybindings

WhichKey

![image](https://user-images.githubusercontent.com/6575405/172647922-12c901a1-6ca4-44e1-acd9-f3da26a23915.png)

Telescope

![image](https://user-images.githubusercontent.com/6575405/172648118-e4b63c94-67ab-4a55-a419-37a3f3d49b0e.png)

TODO:
[ ] Sort which key mappings (Should create a different issue)
[ ] Show key mappings for partial keys, like `ga` and `gao` (Should create a different issue)
[ ] Clean up after finding out `vim.keymap.set('n', '<key>', lua_func, {desc = 'this is what I do'})` does almost all the job