### PR TITLE
Patch: Unit tests shouldn't run on Nightly Neovim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
           # For all versions see https://github.com/neovim/neovim/tags
           - neovim: 0.8.3
           - neovim: 0.9.4
-          - neovim: nightly
     name: "Test with Neovim ${{ matrix.neovim }}"
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Actually... maybe a better solution could be to include nightly as @peterfication already did (and dismiss this PR), but not as a mandatory check.

I see it is possible to define which checks are required:

<img width="748" alt="image" src="https://github.com/johmsalas/text-case.nvim/assets/6575405/f44b9ed1-c9f5-48fe-9d33-20b6c6e9e594">
