### PR TITLE
Added tests for Neovim Nightly and Status Badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on: [pull_request]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: Continuous Integration
 
 on: [pull_request]
 

--- a/.github/workflows/neovim-nightly.yml
+++ b/.github/workflows/neovim-nightly.yml
@@ -1,0 +1,19 @@
+name: Neovim Nightly
+
+on: [pull_request]
+
+jobs:
+  TestsOnNightly:
+    runs-on: ubuntu-latest
+    name: "Test with Neovim Nightly"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install asdf & tools
+      uses: asdf-vm/actions/install@v2
+      with:
+        tool_versions: |
+          neovim nightly
+    - name: Run Tests on Nightly Neovim
+      run: |
+        nvim --version
+        ./tests/run.sh

--- a/.github/workflows/neovim-nightly.yml
+++ b/.github/workflows/neovim-nightly.yml
@@ -1,11 +1,14 @@
 name: Neovim Nightly
 
-on: [pull_request]
+on: 
+  schedule:
+    # Checks daily
+    - cron: '17 11 * * *'
 
 jobs:
   TestsOnNightly:
     runs-on: ubuntu-latest
-    name: "Test with Neovim Nightly"
+    name: "Tests with Neovim Nightly"
     steps:
     - uses: actions/checkout@v4
     - name: Install asdf & tools

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 An all in one plugin for converting text case in Neovim. It converts a piece of text to an indicated string case and also is capable of bulk replacing texts without changing cases
 
+![CI/CD](https://github.com/johmsalas/text-case.nvim/actions/workflows/ci.yml/badge.svg)
+![Tests Neovim Nightly](https://github.com/johmsalas/text-case.nvim/actions/workflows/neovim-nightly.yml/badge.svg)
+
 ## Features
 
 ### Quick conversion


### PR DESCRIPTION
This PR adds status badges to the Readme. 

`All tests` will be always green (ideally) and it communicates the plugin has testing coverage (at some extent so far...)
`Neovim Nightly badge` is updated daily and will communicate when there is a breaking change in the near future

<img width="343" alt="image" src="https://github.com/johmsalas/text-case.nvim/assets/6575405/70abd40a-22b1-4fc7-a7f0-567037b88974">
