### PR TITLE
Adjust options for setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ It is also a library of text case conversion methods. Useful for your LUA code.
 
 ## Setup
 
-Install with your favorite plugin manager. The setup function, sets up the default keybinding. To setup custom key maps, do not call `require('textcase').setup{}`, and follow the example bellow
+Install with your favorite plugin manager.
 
-Example in LUA using Packer.nvim. Default keybinding
+### Example in LUA using Packer.nvim with default options
 
 ```lua
 use { "johmsalas/text-case.nvim",
@@ -81,7 +81,20 @@ use { "johmsalas/text-case.nvim",
 }
 ```
 
-Example in VimScript using Plug. Custom keybinding
+### All options with their default value
+
+```lua
+{
+  -- Set `default_keymappings_enabled` to false if you don't want automatic keymappings to be registered.
+  default_keymappings_enabled = true,
+  -- `prefix` is only considered if `default_keymappings_enabled` is true. It configures the prefix
+  -- of the keymappings, e.g. `gau ` executes the `current_word` method with `to_upper_case`
+  -- and `gaou` executes the `operator` method with `to_upper_case`.
+  prefix = "ga",
+}
+```
+
+### Example in VimScript using Plug with custom keybindings
 
 ```vimscript
 call plug#begin('~/.local/share/nvim/plugged')

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -4,43 +4,7 @@ local plugin = require("textcase.plugin.plugin")
 local api = require("textcase.plugin.api")
 local whichkey = require("textcase.extensions.whichkey")
 
-M.Initialize = function()
-  plugin.register_methods(api.to_upper_case)
-  plugin.register_methods(api.to_lower_case)
-  plugin.register_methods(api.to_snake_case)
-  plugin.register_methods(api.to_dash_case)
-  plugin.register_methods(api.to_title_dash_case)
-  plugin.register_methods(api.to_constant_case)
-  plugin.register_methods(api.to_dot_case)
-  plugin.register_methods(api.to_phrase_case)
-  plugin.register_methods(api.to_camel_case)
-  plugin.register_methods(api.to_pascal_case)
-  plugin.register_methods(api.to_title_case)
-  plugin.register_methods(api.to_path_case)
-  plugin.register_methods(api.to_upper_phrase_case)
-  plugin.register_methods(api.to_lower_phrase_case)
-
-  plugin.register_replace_command("Subs", {
-    api.to_upper_case,
-    api.to_lower_case,
-    api.to_snake_case,
-    api.to_dash_case,
-    api.to_title_dash_case,
-    api.to_constant_case,
-    api.to_dot_case,
-    api.to_phrase_case,
-    api.to_camel_case,
-    api.to_pascal_case,
-    api.to_title_case,
-    api.to_path_case,
-    api.to_upper_phrase_case,
-    api.to_lower_phrase_case,
-  })
-end
-
-M.setup = function(opts)
-  local prefix = opts and opts.prefix or "ga"
-
+local function setup_default_keymappings(prefix)
   whichkey.register("v", {
     [prefix] = {
       name = "text-case",
@@ -98,6 +62,53 @@ M.setup = function(opts)
     operator = "ol",
     lsp_rename = "L",
   })
+end
+
+M.Initialize = function()
+  plugin.register_methods(api.to_upper_case)
+  plugin.register_methods(api.to_lower_case)
+  plugin.register_methods(api.to_snake_case)
+  plugin.register_methods(api.to_dash_case)
+  plugin.register_methods(api.to_title_dash_case)
+  plugin.register_methods(api.to_constant_case)
+  plugin.register_methods(api.to_dot_case)
+  plugin.register_methods(api.to_phrase_case)
+  plugin.register_methods(api.to_camel_case)
+  plugin.register_methods(api.to_pascal_case)
+  plugin.register_methods(api.to_title_case)
+  plugin.register_methods(api.to_path_case)
+  plugin.register_methods(api.to_upper_phrase_case)
+  plugin.register_methods(api.to_lower_phrase_case)
+
+  plugin.register_replace_command("Subs", {
+    api.to_upper_case,
+    api.to_lower_case,
+    api.to_snake_case,
+    api.to_dash_case,
+    api.to_title_dash_case,
+    api.to_constant_case,
+    api.to_dot_case,
+    api.to_phrase_case,
+    api.to_camel_case,
+    api.to_pascal_case,
+    api.to_title_case,
+    api.to_path_case,
+    api.to_upper_phrase_case,
+    api.to_lower_phrase_case,
+  })
+end
+
+M.setup = function(opts)
+  local prefix = opts and opts.prefix or "ga"
+
+  local default_keymappings_enabled = true
+  if opts and opts.default_keymappings_enabled ~= nil then
+    default_keymappings_enabled = opts.default_keymappings_enabled
+  end
+
+  if default_keymappings_enabled then
+    setup_default_keymappings(prefix)
+  end
 end
 
 return M

--- a/tests/textcase/plugin/options/default_keymappings_false_spec.lua
+++ b/tests/textcase/plugin/options/default_keymappings_false_spec.lua
@@ -1,0 +1,26 @@
+local textcase = require("textcase")
+local test_helpers = require("tests.test_helpers")
+
+describe("plugin options default_keymappings_enabled=false", function()
+  before_each(function()
+    textcase.setup({
+      default_keymappings_enabled = false,
+    })
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_command("buffer " .. buf)
+    vim.api.nvim_buf_set_lines(0, 0, -1, true, { "LoremIpsum" })
+  end)
+
+  it("should not register keymappings", function()
+    test_helpers.execute_keys("gac")
+
+    assert.are.same({ "LoremIpsum" }, test_helpers.get_buf_lines())
+  end)
+
+  it("should still be able to execute methods directly", function()
+    test_helpers.execute_keys("<CMD>lua require('textcase').current_word('to_snake_case')<CR>")
+
+    assert.are.same({ "lorem_ipsum" }, test_helpers.get_buf_lines())
+  end)
+end)

--- a/tests/textcase/plugin/options/prefix_spec.lua
+++ b/tests/textcase/plugin/options/prefix_spec.lua
@@ -1,0 +1,26 @@
+local textcase = require("textcase")
+local test_helpers = require("tests.test_helpers")
+
+describe("plugin options prefix", function()
+  before_each(function()
+    textcase.setup({
+      prefix = "gp",
+    })
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_command("buffer " .. buf)
+    vim.api.nvim_buf_set_lines(0, 0, -1, true, { "LoremIpsum" })
+  end)
+
+  it("should set the default keymappings with the passed in prefix", function()
+    test_helpers.execute_keys("gps")
+
+    assert.are.same({ "lorem_ipsum" }, test_helpers.get_buf_lines())
+  end)
+
+  it("the default prefix should not work", function()
+    test_helpers.execute_keys("gac")
+
+    assert.are.same({ "LoremIpsum" }, test_helpers.get_buf_lines())
+  end)
+end)


### PR DESCRIPTION
This way, it's clear to the user how to use the plugin by just looking at the example setup scripts and the presentend default options.

It also allows for other possible options in the future.

This also adds tests for the options.

This PR partially addresses the problems of https://github.com/johmsalas/text-case.nvim/issues/45