### PR TITLE
Add option to select methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ use { "johmsalas/text-case.nvim",
   -- of the keymappings, e.g. `gau ` executes the `current_word` method with `to_upper_case`
   -- and `gaou` executes the `operator` method with `to_upper_case`.
   prefix = "ga",
+  -- By default, all methods are enabled. If you set this option with some methods omitted,
+  -- these methods will not be registered in the default keymappings. The methods will still
+  -- be accessible when calling the exact lua function e.g.:
+  -- "<CMD>lua require('textcase').current_word('to_snake_case')<CR>"
+  enabled_methods = {
+    "to_upper_case",
+    "to_lower_case",
+    "to_snake_case",
+    "to_dash_case",
+    "to_title_dash_case",
+    "to_constant_case",
+    "to_dot_case",
+    "to_phrase_case",
+    "to_camel_case",
+    "to_pascal_case",
+    "to_title_case",
+    "to_path_case",
+    "to_upper_phrase_case",
+    "to_lower_phrase_case",
+  },
 }
 ```
 

--- a/lua/textcase/init.lua
+++ b/lua/textcase/init.lua
@@ -36,6 +36,7 @@ local M = {
   },
   setup = presets.setup,
   init = presets.Initialize,
+  options = presets.options,
   register_keybindings = plugin.register_keybindings,
   register_keys = plugin.register_keys,
   register_replace_command = plugin.register_replace_command,

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -1,4 +1,5 @@
 local M = {}
+M.options = {}
 
 local plugin = require("textcase.plugin.plugin")
 local api = require("textcase.plugin.api")
@@ -21,15 +22,15 @@ local allMethods = {
 }
 
 -- Setup default keymappings for the plugin but only for the methods that are enabled.
-local function setup_default_keymappings(prefix, enabled_methods_set)
+local function setup_default_keymappings()
   whichkey.register("v", {
-    [prefix] = {
+    [M.options.prefix] = {
       name = "text-case",
     },
   })
 
   whichkey.register("n", {
-    [prefix] = {
+    [M.options.prefix] = {
       name = "text-case",
       o = {
         name = "Pending mode operator",
@@ -48,9 +49,9 @@ local function setup_default_keymappings(prefix, enabled_methods_set)
   }
 
   for _, keymapping_definition in ipairs(default_keymapping_definitions) do
-    if enabled_methods_set[keymapping_definition.method_name] then
-      plugin.register_keybindings(prefix, api[keymapping_definition.method_name], {
-        prefix = prefix,
+    if M.options.enabled_methods_set[keymapping_definition.method_name] then
+      plugin.register_keybindings(M.options.prefix, api[keymapping_definition.method_name], {
+        prefix = M.options.prefix,
         quick_replace = keymapping_definition.quick_replace,
         operator = keymapping_definition.operator,
         lsp_rename = keymapping_definition.lsp_rename,
@@ -69,23 +70,25 @@ M.Initialize = function()
   plugin.register_replace_command("Subs", replace_command_methods)
 end
 
+M.enabled_methods_set = {}
+
 M.setup = function(opts)
-  local prefix = opts and opts.prefix or "ga"
+  M.options.prefix = opts and opts.prefix or "ga"
 
-  local default_keymappings_enabled = true
+  M.options.default_keymappings_enabled = true
   if opts and opts.default_keymappings_enabled ~= nil then
-    default_keymappings_enabled = opts.default_keymappings_enabled
+    M.options.default_keymappings_enabled = opts.default_keymappings_enabled
   end
 
-  local enabled_methods = opts and opts.enabled_methods or allMethods
+  M.options.enabled_methods = opts and opts.enabled_methods or allMethods
   -- Turn the enabled_methods into a set for faster lookup
-  local enabled_methods_set = {}
-  for _, method_name in ipairs(enabled_methods) do
-    enabled_methods_set[method_name] = true
+  M.options.enabled_methods_set = {}
+  for _, method_name in ipairs(M.options.enabled_methods) do
+    M.options.enabled_methods_set[method_name] = true
   end
 
-  if default_keymappings_enabled then
-    setup_default_keymappings(prefix)
+  if M.options.default_keymappings_enabled then
+    setup_default_keymappings()
   end
 end
 

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -3,8 +3,25 @@ local M = {}
 local plugin = require("textcase.plugin.plugin")
 local api = require("textcase.plugin.api")
 local whichkey = require("textcase.extensions.whichkey")
+local allMethods = {
+  "to_upper_case",
+  "to_lower_case",
+  "to_snake_case",
+  "to_dash_case",
+  "to_title_dash_case",
+  "to_constant_case",
+  "to_dot_case",
+  "to_phrase_case",
+  "to_camel_case",
+  "to_pascal_case",
+  "to_title_case",
+  "to_path_case",
+  "to_upper_phrase_case",
+  "to_lower_phrase_case",
+}
 
-local function setup_default_keymappings(prefix)
+-- Setup default keymappings for the plugin but only for the methods that are enabled.
+local function setup_default_keymappings(prefix, enabled_methods_set)
   whichkey.register("v", {
     [prefix] = {
       name = "text-case",
@@ -20,82 +37,36 @@ local function setup_default_keymappings(prefix)
     },
   })
 
-  plugin.register_keybindings(prefix, api.to_constant_case, {
-    prefix = prefix,
-    quick_replace = "n",
-    operator = "on",
-    lsp_rename = "N",
-  })
-  plugin.register_keybindings(prefix, api.to_camel_case, {
-    prefix = prefix,
-    quick_replace = "c",
-    operator = "oc",
-    lsp_rename = "C",
-  })
-  plugin.register_keybindings(prefix, api.to_snake_case, {
-    prefix = prefix,
-    quick_replace = "s",
-    operator = "os",
-    lsp_rename = "S",
-  })
-  plugin.register_keybindings(prefix, api.to_dash_case, {
-    prefix = prefix,
-    quick_replace = "d",
-    operator = "od",
-    lsp_rename = "D",
-  })
-  plugin.register_keybindings(prefix, api.to_pascal_case, {
-    prefix = prefix,
-    quick_replace = "p",
-    operator = "op",
-    lsp_rename = "P",
-  })
-  plugin.register_keybindings(prefix, api.to_upper_case, {
-    prefix = prefix,
-    quick_replace = "u",
-    operator = "ou",
-    lsp_rename = "U",
-  })
-  plugin.register_keybindings(prefix, api.to_lower_case, {
-    prefix = prefix,
-    quick_replace = "l",
-    operator = "ol",
-    lsp_rename = "L",
-  })
+  local default_keymapping_definitions = {
+    { method_name = "to_constant_case", quick_replace = "n", operator = "on", lsp_rename = "N" },
+    { method_name = "to_camel_case", quick_replace = "c", operator = "oc", lsp_rename = "C" },
+    { method_name = "to_snake_case", quick_replace = "s", operator = "os", lsp_rename = "S" },
+    { method_name = "to_dash_case", quick_replace = "d", operator = "od", lsp_rename = "D" },
+    { method_name = "to_pascal_case", quick_replace = "p", operator = "op", lsp_rename = "P" },
+    { method_name = "to_upper_case", quick_replace = "u", operator = "ou", lsp_rename = "U" },
+    { method_name = "to_lower_case", quick_replace = "l", operator = "ol", lsp_rename = "L" },
+  }
+
+  for _, keymapping_definition in ipairs(default_keymapping_definitions) do
+    if enabled_methods_set[keymapping_definition.method_name] then
+      plugin.register_keybindings(prefix, api[keymapping_definition.method_name], {
+        prefix = prefix,
+        quick_replace = keymapping_definition.quick_replace,
+        operator = keymapping_definition.operator,
+        lsp_rename = keymapping_definition.lsp_rename,
+      })
+    end
+  end
 end
 
 M.Initialize = function()
-  plugin.register_methods(api.to_upper_case)
-  plugin.register_methods(api.to_lower_case)
-  plugin.register_methods(api.to_snake_case)
-  plugin.register_methods(api.to_dash_case)
-  plugin.register_methods(api.to_title_dash_case)
-  plugin.register_methods(api.to_constant_case)
-  plugin.register_methods(api.to_dot_case)
-  plugin.register_methods(api.to_phrase_case)
-  plugin.register_methods(api.to_camel_case)
-  plugin.register_methods(api.to_pascal_case)
-  plugin.register_methods(api.to_title_case)
-  plugin.register_methods(api.to_path_case)
-  plugin.register_methods(api.to_upper_phrase_case)
-  plugin.register_methods(api.to_lower_phrase_case)
+  local replace_command_methods = {}
+  for _, method_name in ipairs(allMethods) do
+    plugin.register_methods(api[method_name])
+    table.insert(replace_command_methods, api[method_name])
+  end
 
-  plugin.register_replace_command("Subs", {
-    api.to_upper_case,
-    api.to_lower_case,
-    api.to_snake_case,
-    api.to_dash_case,
-    api.to_title_dash_case,
-    api.to_constant_case,
-    api.to_dot_case,
-    api.to_phrase_case,
-    api.to_camel_case,
-    api.to_pascal_case,
-    api.to_title_case,
-    api.to_path_case,
-    api.to_upper_phrase_case,
-    api.to_lower_phrase_case,
-  })
+  plugin.register_replace_command("Subs", replace_command_methods)
 end
 
 M.setup = function(opts)
@@ -104,6 +75,13 @@ M.setup = function(opts)
   local default_keymappings_enabled = true
   if opts and opts.default_keymappings_enabled ~= nil then
     default_keymappings_enabled = opts.default_keymappings_enabled
+  end
+
+  local enabled_methods = opts and opts.enabled_methods or allMethods
+  -- Turn the enabled_methods into a set for faster lookup
+  local enabled_methods_set = {}
+  for _, method_name in ipairs(enabled_methods) do
+    enabled_methods_set[method_name] = true
   end
 
   if default_keymappings_enabled then

--- a/tests/textcase/plugin/options/enabled_methods_spec.lua
+++ b/tests/textcase/plugin/options/enabled_methods_spec.lua
@@ -1,0 +1,26 @@
+local textcase = require("textcase")
+local test_helpers = require("tests.test_helpers")
+
+describe("plugin options default_keymappings=false", function()
+  before_each(function()
+    textcase.setup({
+      enabled_methods = { "to_snake_case" },
+    })
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_command("buffer " .. buf)
+    vim.api.nvim_buf_set_lines(0, 0, -1, true, { "LoremIpsum" })
+  end)
+
+  it("should not register other keymappings", function()
+    test_helpers.execute_keys("gal")
+
+    assert.are.same({ "LoremIpsum" }, test_helpers.get_buf_lines())
+  end)
+
+  it("should still register the enabled key mapping", function()
+    test_helpers.execute_keys("gas")
+
+    assert.are.same({ "lorem_ipsum" }, test_helpers.get_buf_lines())
+  end)
+end)


### PR DESCRIPTION
This PR makes it possible to select the methods that should be registered for the default keymappings. It also prepares the possibility to add this method selection for Telescope.

Partially addresses https://github.com/johmsalas/text-case.nvim/issues/45