### PR TITLE
 Subs command which adds a word will add it twice sometimes

### DIFF
--- a/lua/textcase/plugin/plugin.lua
+++ b/lua/textcase/plugin/plugin.lua
@@ -136,14 +136,26 @@ function M.incremental_substitute(opts, preview_ns, preview_buf)
     local transformed_source = method.apply(source)
     local transformed_dest = dest == "" and "" or method.apply(dest)
 
-    local get_match = utils.get_list(utils.escape_string(transformed_source), mode)
-    for match in get_match do
-      if dest ~= "" then
-        conversion.replace_matches(match, transformed_source, transformed_dest, false, buf)
-      end
-      local length = transformed_dest == "" and #transformed_source or #transformed_dest
-      if preview_ns ~= nil then
-        vim.api.nvim_buf_add_highlight(buf, preview_ns, "Search", match[1] - 1, match[2] - 1, match[2] - 1 + length)
+    if
+      method.method_name == "to_lower_case"
+      and M.state.methods_by_method_name.to_snake_case(source) == transformed_source
+    then
+      -- Ignore to_lower_case if to_snake_case would yield the same result
+    elseif
+      method.method_name == "to_upper_case"
+      and M.state.methods_by_method_name.to_constant_case(source) == transformed_source
+    then
+      -- Ignore to_upper_case if to_constant_case would yield the same result
+    else
+      local get_match = utils.get_list(utils.escape_string(transformed_source), mode)
+      for match in get_match do
+        if dest ~= "" then
+          conversion.replace_matches(match, transformed_source, transformed_dest, false, buf)
+        end
+        local length = transformed_dest == "" and #transformed_source or #transformed_dest
+        if preview_ns ~= nil then
+          vim.api.nvim_buf_add_highlight(buf, preview_ns, "Search", match[1] - 1, match[2] - 1, match[2] - 1 + length)
+        end
       end
     end
   end

--- a/tests/textcase/plugin/plugin_spec.lua
+++ b/tests/textcase/plugin/plugin_spec.lua
@@ -147,34 +147,6 @@ describe("plugin", function()
     end
   end)
 
-  describe("Subs command", function()
-    local test_cases = {
-      {
-        keys = "Vjj<CMD>Subs/lorem_ipsum/elit_sed/<CR>",
-        buffer_lines = {
-          "LoremIpsum DolorSit amet",
-          "lorem_ipsum dolor_sit amet",
-          "lorem-ipsum dolor-sit amet",
-        },
-        expected = {
-          "ElitSed DolorSit amet",
-          "elit_sed dolor_sit amet",
-          "elit-sed dolor-sit amet",
-        },
-      },
-    }
-
-    for _, test_case in ipairs(test_cases) do
-      it("should work for keys `" .. test_case.keys .. "`", function()
-        vim.api.nvim_buf_set_lines(0, 0, -1, true, test_case.buffer_lines)
-
-        test_helpers.execute_keys(test_case.keys)
-
-        assert.are.same(test_case.expected, test_helpers.get_buf_lines())
-      end)
-    end
-  end)
-
   -- it("should stringcase line from register", function()
   --   vim.fn.setreg("a", "stringcase", "")
   --   execute_keys('"agsUU')

--- a/tests/textcase/plugin/subs_spec.lua
+++ b/tests/textcase/plugin/subs_spec.lua
@@ -1,0 +1,79 @@
+local textcase = require("textcase")
+local test_helpers = require("tests.test_helpers")
+
+describe("plugin", function()
+  before_each(function()
+    textcase.setup()
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_command("buffer " .. buf)
+  end)
+
+  describe("Subs command", function()
+    local test_cases = {
+      {
+        keys = "Vjj:Subs/lorem_ipsum/elit_sed/<CR>",
+        buffer_lines = {
+          "LoremIpsum DolorSit amet",
+          "lorem_ipsum dolor_sit amet",
+          "lorem-ipsum dolor-sit amet",
+        },
+        expected = {
+          "ElitSed DolorSit amet",
+          "elit_sed dolor_sit amet",
+          "elit-sed dolor-sit amet",
+        },
+      },
+      -- This test case adds a word in the Subs command
+      {
+        keys = "Vjj:Subs/lorem ipsum/lorem ipsum nunc/<CR>",
+        buffer_lines = {
+          "LoremIpsum DolorSit amet",
+          "lorem_ipsum dolor_sit amet",
+          "lorem-ipsum dolor-sit amet",
+        },
+        expected = {
+          "LoremIpsumNunc DolorSit amet",
+          "lorem_ipsum_nunc dolor_sit amet",
+          "lorem-ipsum-nunc dolor-sit amet",
+        },
+      },
+      {
+        keys = "Vjj:Subs/LoremIpsum/LoremIpsumNunc/<CR>",
+        buffer_lines = {
+          "LoremIpsum DolorSit amet",
+          "lorem_ipsum dolor_sit amet",
+          "lorem-ipsum dolor-sit amet",
+        },
+        expected = {
+          "LoremIpsumNunc DolorSit amet",
+          "lorem_ipsum_nunc dolor_sit amet",
+          "lorem-ipsum-nunc dolor-sit amet",
+        },
+      },
+      {
+        keys = "Vjj:Subs/LOREM IPSUM/LOREM IPSUM NUNC/<CR>",
+        buffer_lines = {
+          "LoremIpsum DolorSit amet",
+          "LOREM_IPSUM dolor_sit amet",
+          "lorem-ipsum dolor-sit amet",
+        },
+        expected = {
+          "LoremIpsumNunc DolorSit amet",
+          "LOREM_IPSUM_NUNC dolor_sit amet",
+          "lorem-ipsum-nunc dolor-sit amet",
+        },
+      },
+    }
+
+    for _, test_case in ipairs(test_cases) do
+      it("should work for keys `" .. test_case.keys .. "`", function()
+        vim.api.nvim_buf_set_lines(0, 0, -1, true, test_case.buffer_lines)
+
+        test_helpers.execute_keys(test_case.keys)
+
+        assert.are.same(test_case.expected, test_helpers.get_buf_lines())
+      end)
+    end
+  end)
+end)


### PR DESCRIPTION
This happens because to_lower_case and to_snake_case, as well as
to_upper_case and to_constant_case can yield the same result and hence a
word is replaced twice.

This only happens if the subs command adds a word, e.g.:

```
:Subs/lorem ipsum/lorem ipsum nunc/
```