### PR TITLE
Add test case for Subs/a/aa

### DIFF
--- a/tests/textcase/plugin/subs_spec.lua
+++ b/tests/textcase/plugin/subs_spec.lua
@@ -64,6 +64,12 @@ describe("plugin", function()
           "lorem-ipsum-nunc dolor-sit amet",
         },
       },
+      -- This test case makes sure that we don't replace endlessly if <to> is 2*<from>
+      {
+        keys = "V:Subs/a/aa<CR>",
+        buffer_lines = { "a" },
+        expected = { "aa" },
+      },
     }
 
     for _, test_case in ipairs(test_cases) do


### PR DESCRIPTION
Makes sure https://github.com/johmsalas/text-case.nvim/issues/36 does not happen again.