### PR TITLE
Use main branch for README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 
-on: [pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   StyLua:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 An all in one plugin for converting text case in Neovim. It converts a piece of text to an indicated string case and also is capable of bulk replacing texts without changing cases
 
-![CI/CD](https://github.com/johmsalas/text-case.nvim/actions/workflows/ci.yml/badge.svg)
-![Tests Neovim Nightly](https://github.com/johmsalas/text-case.nvim/actions/workflows/neovim-nightly.yml/badge.svg)
+![CI/CD](https://github.com/johmsalas/text-case.nvim/actions/workflows/ci.yml/badge.svg?branch=main)
+![Tests Neovim Nightly](https://github.com/johmsalas/text-case.nvim/actions/workflows/neovim-nightly.yml/badge.svg?branch=main)
 
 This plugin runs its tests against the following versions of Neovim:
 


### PR DESCRIPTION
Otherwise, a PR CI failure will lead to a broken badge.

> NOTE: The badge will only start to work when this PR is merged because the main branch has no CI runs yet. Hence, the added push event for CI.