### PR TITLE
fix(Subs): distinguish visual block mode and visual line mode

### DIFF
--- a/lua/textcase/plugin/plugin.lua
+++ b/lua/textcase/plugin/plugin.lua
@@ -135,16 +135,27 @@ end
 -- <cmd>h command-preview
 function M.incremental_substitute(opts, preview_ns, preview_buf)
   local command = "Subs"
+
+  -- preview_ns and preview_buf indicates the buffer to be modified
+  local buf = (preview_ns ~= nil) and preview_buf or vim.api.nvim_get_current_buf()
+
+  local range_start_mark = vim.api.nvim_buf_get_mark(buf, "<")
+  local range_end_mark = vim.api.nvim_buf_get_mark(buf, ">")
+
+  local visual_mode = "\22" -- Visual block mode as default
+  if range_start_mark[2] > 1000000 or range_end_mark[2] > 1000000 then
+    -- If one of the mark has a huge value, it means that "the range
+    -- goes until the end of lines" aka Visual line mode
+    visual_mode = "v" -- Visual line mode
+  end
+
   -- Equivalent to the method TextCaseSubstituteLauncher (start.vim) computing
   -- if it is a multiline selection to use either normal or visual mode
-  local mode = (opts.range < 2 or opts.line1 == opts.line2) and "n" or "\22"
+  local mode = (opts.range < 2 or opts.line1 == opts.line2) and "n" or visual_mode
   local params = vim.split(opts.args, "/")
   local source, dest = params[2], params[3]
   source = MixStringConectors(source)
   dest = MixStringConectors(dest or "")
-
-  -- preview_ns and preview_buf indicates the buffer to be modified
-  local buf = (preview_ns ~= nil) and preview_buf or vim.api.nvim_get_current_buf()
 
   local cursor_pos = vim.fn.getpos(".")
   vim.api.nvim_buf_clear_namespace(buf, 1, 0, -1)

--- a/tests/textcase/plugin/subs_spec.lua
+++ b/tests/textcase/plugin/subs_spec.lua
@@ -137,6 +137,41 @@ describe("plugin", function()
           "nunc-ipsum nunc-dolor-sit amet",
         },
       },
+      -- Test case for a shorter second line
+      -- This tests visual line mode vs visual block mode
+      {
+        keys = "<C-V>ej:Subs/lorem/nunc<CR>",
+        buffer_lines = {
+          "  LoremIpsum LoremDolorSit amet",
+          "short",
+        },
+        expected = {
+          "  NuncIpsum LoremDolorSit amet",
+          "short",
+        },
+      },
+      {
+        keys = "Vj:Subs/lorem/nunc<CR>",
+        buffer_lines = {
+          "  LoremIpsum LoremDolorSit amet",
+          "short",
+        },
+        expected = {
+          "  NuncIpsum NuncDolorSit amet",
+          "short",
+        },
+      },
+      {
+        keys = ":Subs/lorem/nunc<CR>",
+        buffer_lines = {
+          "  LoremIpsum LoremDolorSit amet",
+          "short",
+        },
+        expected = {
+          "  NuncIpsum NuncDolorSit amet",
+          "short",
+        },
+      },
     }
 
     for _, test_case in ipairs(test_cases) do


### PR DESCRIPTION
Until now, it was only working properly for visual block mode. If visual
line had a short last line selected, it wouldn't work because in visual
block mode, this means that the range is as short as the last line.

So if the last line was a line with 0 chars, which can happen easily
in coding files, it would not work.

Example:

```typescript
const foo = "bar";
const bar = "bar";

console.log(foo);
````

In this example, selecting the first two lines and doing a `Subs` will
work as expected. However, if the third line is selected, nothing will
happen because the third line has 0 chars and hence the visual block
mode will have a range of 0 chars.

**This change fixes that.**

Fixes https://github.com/johmsalas/text-case.nvim/issues/117