### PR TITLE
fix: Correct documentation for LazyVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ use { "johmsalas/text-case.nvim",
 {
   "johmsalas/text-case.nvim",
   dependencies = { "nvim-telescope/telescope.nvim" },
+  lazy = false, -- required for using the default keymaps
   config = function()
     require("textcase").setup({})
     require("telescope").load_extension("textcase")


### PR DESCRIPTION
Lazyvim default mapping was only loaded after using Telescope.
This is a quick PR for mitigating the issue in the readme.