### PR TITLE
feat(Subs): adjustable name for substitude command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ use { "johmsalas/text-case.nvim",
 {
   "johmsalas/text-case.nvim",
   dependencies = { "nvim-telescope/telescope.nvim" },
-  -- Author's Note: If default keymappings fail to register (possible config issue in my local setup), 
+  -- Author's Note: If default keymappings fail to register (possible config issue in my local setup),
   -- verify lazy loading functionality. On failure, disable lazy load and report issue
   -- lazy = false,
   config = function()
@@ -114,6 +114,9 @@ use { "johmsalas/text-case.nvim",
   -- of the keymappings, e.g. `gau ` executes the `current_word` method with `to_upper_case`
   -- and `gaou` executes the `operator` method with `to_upper_case`.
   prefix = "ga",
+  -- If `substitude_command_name` is not nil, an additional command with the passed in name
+  -- will be created that does the same thing as "Subs" does.
+  substitude_command_name = nil,
   -- By default, all methods are enabled. If you set this option with some methods omitted,
   -- these methods will not be registered in the default keymappings. The methods will still
   -- be accessible when calling the exact lua function e.g.:

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -60,14 +60,18 @@ local function setup_default_keymappings()
   end
 end
 
-M.Initialize = function()
+local function register_replace_command(substitude_command_name)
   local replace_command_methods = {}
   for _, method_name in ipairs(all_methods) do
     plugin.register_methods(api[method_name])
     table.insert(replace_command_methods, api[method_name])
   end
 
-  plugin.register_replace_command("Subs", replace_command_methods)
+  plugin.register_replace_command(substitude_command_name, replace_command_methods)
+end
+
+M.Initialize = function()
+  register_replace_command("Subs")
 end
 
 -- Set all methods as default in case the setup function is not called.
@@ -75,6 +79,12 @@ M.enabled_methods_set = all_methods
 
 M.setup = function(opts)
   M.options.prefix = opts and opts.prefix or "ga"
+
+  if opts and opts.substitude_command_name ~= nil then
+    -- Register the substitude command with the passed in name again.
+    -- This is needed because we don't require the user to call the setup function.
+    register_replace_command(opts.substitude_command_name)
+  end
 
   M.options.default_keymappings_enabled = true
   if opts and opts.default_keymappings_enabled ~= nil then

--- a/tests/textcase/plugin/options/substitue_command_name_spec.lua
+++ b/tests/textcase/plugin/options/substitue_command_name_spec.lua
@@ -1,0 +1,26 @@
+local textcase = require("textcase")
+local test_helpers = require("tests.test_helpers")
+
+describe("plugin options substitude_command_name", function()
+  before_each(function()
+    textcase.setup({
+      substitude_command_name = "Magic",
+    })
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_command("buffer " .. buf)
+    vim.api.nvim_buf_set_lines(0, 0, -1, true, { "LoremIpsum", "LoremNunc" })
+  end)
+
+  it("should execute the custom substitude command with the passed in name", function()
+    test_helpers.execute_keys("Vj:Magic/lorem/dolor<CR>")
+
+    assert.are.same({ "DolorIpsum", "DolorNunc" }, test_helpers.get_buf_lines())
+  end)
+
+  it("should execute the default substitude command", function()
+    test_helpers.execute_keys("Vj:Subs/lorem/dolor<CR>")
+
+    assert.are.same({ "DolorIpsum", "DolorNunc" }, test_helpers.get_buf_lines())
+  end)
+end)


### PR DESCRIPTION
Fixes https://github.com/johmsalas/text-case.nvim/issues/129

NOTE: After this is merged, a refactor of the replace commands could make sense. Right now, the inner workings are still hard coded to the name `Subs`. And it registers the same methods for both commands in the plugin state.