### PR TITLE
fix(docs): Updates LazyVim example setup to lazy load on all default invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ use { "johmsalas/text-case.nvim",
     require("telescope").load_extension("textcase")
   end,
   keys = {
+    "ga", -- Default invocation prefix
     { "ga.", "<cmd>TextCaseOpenTelescope<CR>", mode = { "n", "v" }, desc = "Telescope" },
   },
 }

--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ use { "johmsalas/text-case.nvim",
 {
   "johmsalas/text-case.nvim",
   dependencies = { "nvim-telescope/telescope.nvim" },
-  -- Author's Note: If default keymappings fail to register (possible config issue in my local setup),
-  -- verify lazy loading functionality. On failure, disable lazy load and report issue
-  -- lazy = false,
   config = function()
     require("textcase").setup({})
     require("telescope").load_extension("textcase")


### PR DESCRIPTION
The example would previously only register the Telescope command for lazy loading the entire plugin.