### PR TITLE
Fix: create only visual mode mappings, not select mode mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ use { "johmsalas/text-case.nvim",
   end,
   keys = {
     "ga", -- Default invocation prefix
-    { "ga.", "<cmd>TextCaseOpenTelescope<CR>", mode = { "n", "v" }, desc = "Telescope" },
+    { "ga.", "<cmd>TextCaseOpenTelescope<CR>", mode = { "n", "x" }, desc = "Telescope" },
   },
 }
 ```

--- a/lua/textcase/extensions/whichkey.lua
+++ b/lua/textcase/extensions/whichkey.lua
@@ -9,8 +9,8 @@ function M.register(mode, mappings)
       noremap = true,
       nowait = true,
     },
-    v = {
-      mode = "v",
+    x = {
+      mode = "x",
       buffer = nil,
       silent = true,
       noremap = true,

--- a/lua/textcase/plugin/plugin.lua
+++ b/lua/textcase/plugin/plugin.lua
@@ -37,7 +37,7 @@ function M.register_keybindings(prefix, method_table, keybindings, opts)
     if keybindings[feature] ~= nil then
       local mode = "n"
       if feature == "visual" then
-        mode = "v"
+        mode = "x"
       end
       local desc = method_table.desc
 
@@ -68,7 +68,7 @@ function M.register_keybindings(prefix, method_table, keybindings, opts)
       .. "')<cr>"
 
     vim.keymap.set("n", keybind, command, { desc = desc })
-    vim.keymap.set("v", keybind, command, { desc = desc })
+    vim.keymap.set("x", keybind, command, { desc = desc })
   end
 end
 

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -23,7 +23,7 @@ local all_methods = {
 
 -- Setup default keymappings for the plugin but only for the methods that are enabled.
 local function setup_default_keymappings()
-  whichkey.register("v", {
+  whichkey.register("x", {
     [M.options.prefix] = {
       name = "text-case",
     },

--- a/tests/textcase/telescope/telescope_spec.lua
+++ b/tests/textcase/telescope/telescope_spec.lua
@@ -43,7 +43,7 @@ describe("Telescope Integration", function()
   describe("visual mode via ga. keymapping", function()
     before_each(function()
       vim.api.nvim_set_keymap("n", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
-      vim.api.nvim_set_keymap("v", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
+      vim.api.nvim_set_keymap("x", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
     end)
 
     local buffer_lines = {
@@ -70,7 +70,7 @@ describe("Telescope Integration", function()
   describe("visual mode lines via ga. keymapping", function()
     before_each(function()
       vim.api.nvim_set_keymap("n", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
-      vim.api.nvim_set_keymap("v", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
+      vim.api.nvim_set_keymap("x", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
     end)
 
     local buffer_lines = {
@@ -97,7 +97,7 @@ describe("Telescope Integration", function()
   describe("visual block mode via ga. keymapping", function()
     before_each(function()
       vim.api.nvim_set_keymap("n", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
-      vim.api.nvim_set_keymap("v", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
+      vim.api.nvim_set_keymap("x", "ga.", "<cmd>TextCaseOpenTelescope<CR>", { desc = "Telescope" })
     end)
 
     describe("when the words are aligned", function()


### PR DESCRIPTION
Hi! I noticed that this plugin uses `v` to create mappings. This is a common mistake. `v` creates the keymaps in both Visual _and_ Select mode. It makes sense to me to only create the keymaps in select mode. For this, `x` should be used instead. Here's `:help map-table`:

| Mode Command | Norm | Ins | Cmd | Vis | Sel | Opr | Term | Lang |
| ------------ | ---- | --- | --- | --- | --- | --- | ---- | ---- |
| ...          |      |     |     |     |     |     |      |      |
| `v[nore]map` | -    | -   | -   | yes | yes | -   | -    | -    |
| `x[nore]map` | -    | -   | -   | yes | -   | -   | -    | -    |
