### PR TITLE
fix: use whichkey.add instead of whichkey.register

### DIFF
--- a/lua/textcase/extensions/whichkey.lua
+++ b/lua/textcase/extensions/whichkey.lua
@@ -1,26 +1,29 @@
 local M = {}
 
-function M.register(mode, mappings)
-  local opts = {
-    n = {
-      mode = "n",
-      buffer = nil,
-      silent = true,
-      noremap = true,
-      nowait = true,
-    },
-    x = {
-      mode = "x",
-      buffer = nil,
-      silent = true,
-      noremap = true,
-      nowait = true,
-    },
-  }
-
+function M.register_prefix(mode, prefix, name)
   local ok, whichkey = pcall(require, "which-key")
   if ok then
-    whichkey.register(mappings, opts[mode])
+    if whichkey.add then
+      -- whichkey.register() is deprecated in favor of whichkey.add()
+      whichkey.add({
+        prefix,
+        group = name,
+        mode = mode,
+        buffer = nil,
+        silent = true,
+        noremap = true,
+        nowait = true,
+      })
+    else
+      -- fallback to whichkey.register() if whichkey.add() is unavailable
+      whichkey.register({ [prefix] = { name = name } }, {
+        mode = mode,
+        buffer = nil,
+        silent = true,
+        noremap = true,
+        nowait = true,
+      })
+    end
   end
 end
 

--- a/lua/textcase/plugin/presets.lua
+++ b/lua/textcase/plugin/presets.lua
@@ -23,20 +23,9 @@ local all_methods = {
 
 -- Setup default keymappings for the plugin but only for the methods that are enabled.
 local function setup_default_keymappings()
-  whichkey.register("x", {
-    [M.options.prefix] = {
-      name = "text-case",
-    },
-  })
-
-  whichkey.register("n", {
-    [M.options.prefix] = {
-      name = "text-case",
-      o = {
-        name = "Pending mode operator",
-      },
-    },
-  })
+  whichkey.register_prefix("x", M.options.prefix, "text-case")
+  whichkey.register_prefix("n", M.options.prefix, "text-case")
+  whichkey.register_prefix("n", M.options.prefix .. "o", "Pending mode operator")
 
   local default_keymapping_definitions = {
     { method_name = "to_constant_case", quick_replace = "n", operator = "on", lsp_rename = "N" },


### PR DESCRIPTION
Fixes #169

Also refactors the extension a little bit to hide the version-specific shape of the whichkey spec inside of `extensions/whichkey.lua`.